### PR TITLE
Updated Main Coding Standards Rule 43 to throw NotImplementedException instead of ArgumentOutOfRangeException

### DIFF
--- a/coding-standards/csharp.md
+++ b/coding-standards/csharp.md
@@ -359,7 +359,7 @@ date: 2022-01-15
         case AccountType.Business:
             return somethingElse;
         default:
-            throw NotImplementedException($"unhandled switch case: {accountType}");
+            throw new NotImplementedException($"unhandled switch case: {accountType}");
     }
     ```
 

--- a/coding-standards/csharp.md
+++ b/coding-standards/csharp.md
@@ -359,7 +359,7 @@ date: 2022-01-15
         case AccountType.Business:
             return somethingElse;
         default:
-            throw new ArgumentOutOfRangeException(nameof(AccountType));
+            throw NotImplementedException($"unhandled switch case: {accountType}");
     }
     ```
 

--- a/coding-standards/pocu-csharp.md
+++ b/coding-standards/pocu-csharp.md
@@ -370,7 +370,7 @@ date: 2022-01-15
         case AccountType.Business:
             return somethingElse;
         default:
-            throw new ArgumentOutOfRangeException(nameof(AccountType));
+            throw new NotImplementedException($"unhandled switch case: {accountType}");
     }
     ```
 


### PR DESCRIPTION
Throw `NotImplementedException` instead of `ArgumentOutOfRangeException` when `switch`-`default` is used to catch missing enum-value handling logic

Reasons for change:
1. `ArgumentOutOfRangeException` is specifically for method params, not for missing switch cases, so it is not appropriate for this context
2. Using `ArgumentOutOfRangeException` this way violates Code Analysis rule CA2208