### PR TITLE
Updated link to english docs and No.3 item's error

### DIFF
--- a/coding-standards/cpp.md
+++ b/coding-standards/cpp.md
@@ -3,7 +3,7 @@ title: "C++ 코딩 표준"
 date: 2021-02-24
 ---
 
-* 원문(영어): [C++ Coding Standards](https://docs.google.com/document/d/1cT8EPgMXe0eopeHvwuFmbHG4TJr5kUmcovkr5irQZmo/edit )
+* 원문(영어): [C++ Coding Standards](https://docs.popekim.com/en/coding-standards/cpp)
 
 ## 머리말
 ### 기본 원칙
@@ -36,7 +36,7 @@ date: 2021-02-24
     }
     ```
 
-3. 메서드 또는 함수 이름은 동사로 시작한다.
+3. 메서드 이름은 동사-목적어 쌍으로 표기한다.
     
     a. public 메서드의 이름은 파스칼 표기법을 따른다.
     ```cpp

--- a/coding-standards/pocu-cpp.md
+++ b/coding-standards/pocu-cpp.md
@@ -6,7 +6,7 @@ date: 2021-02-24
 본 코딩 표준은 [Pope Kim의 C++ 코딩 표준](/ko/coding-standards/cpp)을 [POCU 아카데미](https://pocu.academy/ko/)에 적합하게 수정한 것입니다. 취소선(~~취소선~~) 표시가 된 항목들은 무시해주세요. 
 
 
-* 원문(영어): [C++ Coding Standards](https://docs.google.com/document/d/1cT8EPgMXe0eopeHvwuFmbHG4TJr5kUmcovkr5irQZmo/edit )
+* 원문(영어): [C++ Coding Standards](https://docs.popekim.com/en/coding-standards/cpp)
 
 ## 머리말
 ### 기본 원칙
@@ -32,7 +32,7 @@ date: 2021-02-24
     }
     ```
 
-3. 메서드 또는 함수 이름은 동사로 시작한다.
+3. 메서드 이름은 동사-목적어 쌍으로 표기한다.
 
     a. public 메서드의 이름은 파스칼 표기법을 따른다.
 


### PR DESCRIPTION
원문으로 가는 링크를 수정했고,
Use verb-object pairs for method names         는
메서드 또는 함수 이름은 동사로 시작한다.      로 번역되기에는 살짝 오류가 있어 보여
메서드 이름은 동사-목적어 쌍으로 표기한다.  로 고쳤습니다.